### PR TITLE
Remove dependency convergence rule, since it is way too strict.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## Version 9
 
-* 2015-01-02 - (standard) Add DependencyConvergence rule to maven-enforcer plugin
 * 2015-01-01 - (smoketest) Move the smoketest to integration testing.
 * 2014-12-31 - (standard) Add a minimal formatter for jul.SimpleFormatter (suggested by @dain)
 

--- a/standard/pom.xml
+++ b/standard/pom.xml
@@ -81,7 +81,6 @@
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <configuration>
                         <rules>
-                            <DependencyConvergence />
                             <!-- The following dependencies are hazardous for builds. -->
                             <bannedDependencies>
                                 <excludes>


### PR DESCRIPTION
e.g. if you depend on LibA and LibB, which depend on different versions of LibC, your build will fail.
If you don't control LibA and LibB, this is *extremely* inconvenient to deal with.