### PR TITLE
basepom-policy 4 with checkstyle suppressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Version 9
 
+* 2015-01-14 - (foundation) basepom-policy 4 with improved Checkstyle exclusions for annotations and generated-sources
 * 2015-01-02 - (standard) Add DependencyConvergence rule to maven-enforcer plugin
 * 2015-01-01 - (smoketest) Move the smoketest to integration testing.
 * 2014-12-31 - (standard) Add a minimal formatter for jul.SimpleFormatter (suggested by @dain)

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -112,7 +112,7 @@
         <basepom.maven.version>3.0.5</basepom.maven.version>
 
         <!-- policy jar for license and checkstyle defaults -->
-        <dep.basepom-policy.version>3</dep.basepom-policy.version>
+        <dep.basepom-policy.version>4</dep.basepom-policy.version>
 
         <dep.findbugs.version>3.0.0</dep.findbugs.version>
         <dep.pmd.version>5.2.3</dep.pmd.version>


### PR DESCRIPTION
NOTE: requires merge of https://github.com/basepom/basepom-policy/pull/1 and then release as version 4 before this can merge.