### PR TITLE
Remove ban of cglib, so we can manage asm version if we need to

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 11
 
+* 2015-02-24 - (standard) Ban asm < 5.0.2 which is broken on Java 8
+* 2015-02-24 - (standard) Remove ban of 'cglib', since 'cglib-nodep' uses an old version of ASM which is not Java 8 compatible.
 * 2015-02-08 - (foundation) Change git-id default configuration (https://github.com/ktoso/maven-git-commit-id-plugin/issues/156)
 * 2015-02-08 - (standard-oss) Upgrade license plugin to 2.8 (from 2.7)
 * 2015-02-08 - (standard-oss) Support YAML files for the license plugin

--- a/standard/pom.xml
+++ b/standard/pom.xml
@@ -105,6 +105,8 @@
                                     <exclude>org.mortbay.jetty:servlet-api-2.5</exclude>
                                     <!-- 1.8 and 1.9 are generified badly -->
                                     <exclude>commons-configuration:commons-configuration:[1.8,1.9]</exclude>
+                                    <!-- Old asm versions break on Java 8 code -->
+                                    <exclude>org.ow2.asm:asm:[,5.0.2)</exclude>
                                 </excludes>
                                 <includes>
                                     <!-- whitelist the well numbered guava releases -->

--- a/standard/pom.xml
+++ b/standard/pom.xml
@@ -89,8 +89,6 @@
                                 <excludes>
                                     <!-- clashes with commons-logging:commons-logging -->
                                     <exclude>commons-logging:commons-logging-api</exclude>
-                                    <!-- clashes with cglib:cglib-nodep -->
-                                    <exclude>cglib:cglib</exclude>
                                     <!-- junit repackages hamcrest into its own jar, which is a big no-no.
                                          junit-dep fixes this problem -->
                                     <exclude>junit:junit-dep</exclude>

--- a/standard/pom.xml
+++ b/standard/pom.xml
@@ -89,8 +89,8 @@
                                 <excludes>
                                     <!-- clashes with commons-logging:commons-logging -->
                                     <exclude>commons-logging:commons-logging-api</exclude>
-                                    <!-- junit repackages hamcrest into its own jar, which is a big no-no.
-                                         junit-dep fixes this problem -->
+                                    <!-- junit < 4.12 repackages hamcrest into its own jar, which is a big no-no.
+                                         junit-dep was a transitional fix, but now junit proper has the fix -->
                                     <exclude>junit:junit-dep</exclude>
                                     <exclude>junit:junit:[,4.11)</exclude>
                                     <!-- completely and utterly broken -->


### PR DESCRIPTION
This does mean you could end up with both `cglib` and `cglib-nodep` in which case you'll need to exclude one or the other.  But banning `cglib-nodep` seems like too big of a hammer and will make everyone hate us.