### PR TITLE
Add dependency-management-plugin

### DIFF
--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -160,7 +160,7 @@
         <dep.plugin.dependency-versions-check.version>2.0.2</dep.plugin.dependency-versions-check.version>
 
         <!-- https://github.com/HubSpot/dependency-management-plugin/releases -->
-        <dep.plugin.dependency-management.version>0.3</dep.plugin.dependency-management.version>
+        <dep.plugin.dependency-management.version>0.4</dep.plugin.dependency-management.version>
 
         <!-- https://github.com/basepom/duplicate-finder-maven-plugin/releases -->
         <dep.plugin.duplicate-finder.version>1.2.0</dep.plugin.duplicate-finder.version>
@@ -464,6 +464,8 @@
                         <requireManagement>
                             <dependencies>true</dependencies>
                             <plugins>true</plugins>
+                            <allowVersions>false</allowVersions>
+                            <allowExclusions>false</allowExclusions>
                         </requireManagement>
                     </configuration>
                 </plugin>

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -65,6 +65,7 @@
         <basepom.check.skip-enforcer>${basepom.check.skip-basic}</basepom.check.skip-enforcer>
         <basepom.check.skip-dependency>${basepom.check.skip-basic}</basepom.check.skip-dependency>
         <basepom.check.skip-duplicate-finder>${basepom.check.skip-basic}</basepom.check.skip-duplicate-finder>
+        <basepom.check.skip-dependency-management>${basepom.check.skip-basic}</basepom.check.skip-dependency-management>
         <basepom.check.skip-dependency-versions-check>${basepom.check.skip-basic}</basepom.check.skip-dependency-versions-check>
 
         <!-- extended checks -->
@@ -84,6 +85,7 @@
         <basepom.check.fail-enforcer>${basepom.check.fail-basic}</basepom.check.fail-enforcer>
         <basepom.check.fail-dependency>${basepom.check.fail-basic}</basepom.check.fail-dependency>
         <basepom.check.fail-duplicate-finder>${basepom.check.fail-basic}</basepom.check.fail-duplicate-finder>
+        <basepom.check.fail-dependency-management>${basepom.check.fail-basic}</basepom.check.fail-dependency-management>
         <basepom.check.fail-dependency-versions-check>${basepom.check.fail-basic}</basepom.check.fail-dependency-versions-check>
 
         <!-- extended checks -->
@@ -103,6 +105,7 @@
 
         <!-- Some plugins can run early ("validate") or late ("verify") -->
         <basepom.check.phase-dependency-versions-check>verify</basepom.check.phase-dependency-versions-check>
+        <basepom.check.phase-dependency-management>verify</basepom.check.phase-dependency-management>
         <basepom.check.phase-checkstyle>verify</basepom.check.phase-checkstyle>
 
         <!-- Invoker (Integration testing) -->
@@ -155,6 +158,9 @@
 
         <!-- https://github.com/ning/maven-dependency-versions-check-plugin/releases -->
         <dep.plugin.dependency-versions-check.version>2.0.2</dep.plugin.dependency-versions-check.version>
+
+        <!-- https://github.com/HubSpot/dependency-management-plugin/releases -->
+        <dep.plugin.dependency-management.version>0.3</dep.plugin.dependency-management.version>
 
         <!-- https://github.com/basepom/duplicate-finder-maven-plugin/releases -->
         <dep.plugin.duplicate-finder.version>1.2.0</dep.plugin.duplicate-finder.version>
@@ -445,6 +451,20 @@
                         <skip>${basepom.check.skip-dependency-versions-check}</skip>
                         <failBuildInCaseOfConflict>${basepom.check.fail-dependency-versions-check}</failBuildInCaseOfConflict>
                         <failOnWarning>${basepom.check.fail-dependency-versions-check}</failOnWarning>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>com.hubspot.maven.plugins</groupId>
+                    <artifactId>dependency-management-plugin</artifactId>
+                    <version>${dep.plugin.dependency-management.version}</version>
+                    <configuration>
+                        <skip>${basepom.check.skip-dependency-management}</skip>
+                        <fail>${basepom.check.fail-dependency-management}</fail>
+                        <requireManagement>
+                            <dependencies>true</dependencies>
+                            <plugins>true</plugins>
+                        </requireManagement>
                     </configuration>
                 </plugin>
 
@@ -777,6 +797,20 @@
                         <phase>${basepom.check.phase-dependency-versions-check}</phase>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.hubspot.maven.plugins</groupId>
+                <artifactId>dependency-management-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>${basepom.check.phase-dependency-management}</phase>
+                        <goals>
+                            <goal>analyze</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR adds the [dependency-management-plugin](https://github.com/HubSpot/dependency-management-plugin) to the build lifecycle. As configured, the plugin validates that all dependencies and plugins appear in dependency management, and that the resolved versions match the managed versions (ie, the managed version isn't being overridden inside the `<dependencies>` section). Making all dependencies and plugins managed is best practice and this plugin allows you to enforce it.

In case a child wants to intentionally override a managed version, you have two choices. If the parent uses a property for the dependency version, you can override the property. Otherwise, you can add a dependency management section to the child POM and override the version there. This is pretty standard but the plugin just enforces that you do it this way rather than overriding versions inside the `<dependencies>` tag (which in our experience is often accidental).

@hgschmie @stevenschlansker 