### PR TITLE
update commons-collections to v3.2.2 "Version 3.2.1 has a CVSS 10.0 vulnerability."

### DIFF
--- a/standard/pom.xml
+++ b/standard/pom.xml
@@ -35,7 +35,7 @@
         <!-- Dependency versions that should be the same everywhere. -->
         <dep.commons-beanutils.version>1.9.2</dep.commons-beanutils.version>
         <dep.commons-codec.version>1.10</dep.commons-codec.version>
-        <dep.commons-collections.version>3.2.1</dep.commons-collections.version>
+        <dep.commons-collections.version>3.2.2</dep.commons-collections.version>
         <dep.commons-collections4.version>4.0</dep.commons-collections4.version>
         <dep.commons-configuration.version>1.10</dep.commons-configuration.version>
         <dep.commons-io.version>2.4</dep.commons-io.version>


### PR DESCRIPTION
rebase of https://github.com/stevenschlansker/basepom/pull/1