### PR TITLE
Remove needless specification of empty PMD ruleset

### DIFF
--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -512,7 +512,6 @@
                         <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
                         <minimumTokens>100</minimumTokens>
                         <failurePriority>${basepom.pmd.fail-level}</failurePriority>
-                        <rulesets />
                     </configuration>
                 </plugin>
 

--- a/minimal/pom.xml
+++ b/minimal/pom.xml
@@ -106,7 +106,7 @@
                     <artifactId>maven-pmd-plugin</artifactId>
                     <configuration>
                         <excludeRoots>
-                            <excludeRoot>target/generated-sources/stubs</excludeRoot>
+                            <excludeRoot>target/generated-sources</excludeRoot>
                         </excludeRoots>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
The defaults are sensible, you can already turn the plugin off if you like. 
It doesn't make much sense to turn it on but then default to an empty ruleset
that trivially passes.