### PR TITLE
Align transformers

### DIFF
--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -1003,7 +1003,7 @@
                                     <goal>shade</goal>
                                 </goals>
                                 <configuration>
-                                    <transformers>
+                                    <transformers combine.children="append">
                                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                             <mainClass>${basepom.shaded.main-class}</mainClass>
                                         </transformer>

--- a/minimal/pom.xml
+++ b/minimal/pom.xml
@@ -147,7 +147,6 @@
                             <!-- replace with <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" > -->
                             <!-- once http://jira.codehaus.org/browse/MSHADE-165 is applied to the shade plugin and the plugin is released. -->
                             <transformer implementation="org.basepom.maven.shade.CollectingManifestResourceTransformer">
-                                <mainClass>${basepom.shaded.main-class}</mainClass>
                                 <collectSections>true</collectSections>
                                 <manifestEntries>
                                     <X-BasePOM-Build-Id>${basepom.shaded.id}</X-BasePOM-Build-Id>


### PR DESCRIPTION
basepom-22 broke the use of the `build.executable` profile in the minimal pom. The relocated transformers block ends up overriding the minimal pom configuration with the effect of *removing* the `ServicesResourceTransformer` from the configuration, which breaks service discovery in some applications (e.g., dropwizard). The `CollectingManifestResourceTransformer` is removed as well.

This propose change fixes that situation by configuring the profile to append its configuration. The minimal pom aligns with foundation by removing the main-class configuration from CollectingManifestResourceTransformer, relying on the profile to add it back.

This does not address the missing shade plugin upgrade (#31). I presume that when the shade plugin is in fact upgraded it will include the bugfix that CollectingManifestResourceTransformer works around, and the custom shade plugin configuration in minimal can be moved back to foundation.