### PR TITLE
Update maven-dependency-plugin to 3.0.1

### DIFF
--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -181,7 +181,7 @@
 
         <!-- tools -->
         <dep.plugin.assembly.version>3.0.0</dep.plugin.assembly.version>
-        <dep.plugin.dependency.version>2.10</dep.plugin.dependency.version>
+        <dep.plugin.dependency.version>3.0.1</dep.plugin.dependency.version>
         <dep.plugin.enforcer.version>1.4.1</dep.plugin.enforcer.version>
         <dep.plugin.invoker.version>2.0.0</dep.plugin.invoker.version>
         <dep.plugin.release.version>2.5.3</dep.plugin.release.version>


### PR DESCRIPTION
Upgrades the version of maven-dependency-plugin to 3.0.1, I'm running into [MDEP-506](https://issues.apache.org/jira/browse/MDEP-506), but the current version is rather old so probably best to bump the version to latest.