### PR TITLE
Allow configuration of flags for really-executable-jars-maven-plugin

### DIFF
--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -140,6 +140,7 @@
         <basepom.dependency-management.plugins>false</basepom.dependency-management.plugins>
 
         <!-- executable plugin -->
+        <basepom.executable.flags />
         <basepom.executable.name>${project.name}</basepom.executable.name>
 
         <!-- Some plugins can run early ("validate") or late ("verify") -->
@@ -1057,6 +1058,7 @@
                                 </goals>
                                 <configuration>
                                     <classifier>shaded</classifier>
+                                    <flags>${basepom.executable.flags}</flags>
                                     <programFile>${basepom.executable.name}</programFile>
                                     <attachProgramFile>true</attachProgramFile>
                                 </configuration>


### PR DESCRIPTION
Added `basepom.executable.flags` property whose value will be interpolated into the java invocation as "java $flags -jar ..." by the `really-executable-jars-maven-plugin`.