### PR TITLE
Always print failing PMD errors to console

### DIFF
--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -535,6 +535,7 @@
                     <configuration>
                         <skip>${basepom.check.skip-pmd}</skip>
                         <failOnViolation>${basepom.check.fail-pmd}</failOnViolation>
+                        <printFailingErrors>true</printFailingErrors>
                         <targetJdk>${project.build.targetJdk}</targetJdk>
                         <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
                         <minimumTokens>100</minimumTokens>


### PR DESCRIPTION
Currently, PMD is configured to output to `target/pmd.xml`. This additionally prints the errors to console. 