### PR TITLE
duplicate finder 1.3.0 with default ignore of 'module-info'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Version 26
+
+* 2018-03-15 - (foundation) upgrade duplicate-finder-plugin to 1.3.0 (from 1.2.1)
+
 ## Version 25
 
 * 2017-11-10 - (foundation) Upgrade javadoc plugin to 3.0.0-M1 (from 2.10.4)

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -209,7 +209,7 @@
         <dep.plugin.dependency-scope.version>0.8</dep.plugin.dependency-scope.version>
 
         <!-- https://github.com/basepom/duplicate-finder-maven-plugin/releases -->
-        <dep.plugin.duplicate-finder.version>1.2.1</dep.plugin.duplicate-finder.version>
+        <dep.plugin.duplicate-finder.version>1.3.0</dep.plugin.duplicate-finder.version>
 
         <!-- https://github.com/gleclaire/findbugs-maven-plugin/releases -->
         <dep.plugin.findbugs.version>3.0.5</dep.plugin.findbugs.version>


### PR DESCRIPTION
all the libraries are starting to put this in, causing all sorts of fun with the duplicate checker.