### PR TITLE
Separate spotbugs and spotbugs plugin variables. Keep identical by de…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Version 28
+
+* 2018-09-26 - (foundation) Separate the spotbugs core and spotbugs plugin
+version properties. They are identical by default.
+
 ## Version 27
 
 * 2018-09-07 - (foundation) Upgrade PMD to 6.7.0 (from 6.5.0)

--- a/foundation/pom.xml
+++ b/foundation/pom.xml
@@ -208,7 +208,8 @@
         <dep.plugin.duplicate-finder.version>1.3.0</dep.plugin.duplicate-finder.version>
 
         <!-- https://github.com/spotbugs/spotbugs-maven-plugin/releases -->
-        <dep.plugin.spotbugs.version>3.1.6</dep.plugin.spotbugs.version>
+        <dep.spotbugs.version>3.1.6</dep.spotbugs.version>
+        <dep.plugin.spotbugs.version>${dep.spotbugs.version}</dep.plugin.spotbugs.version>
 
         <!-- https://github.com/jacoco/jacoco/releases -->
         <dep.plugin.jacoco.version>0.8.2</dep.plugin.jacoco.version>
@@ -494,6 +495,13 @@
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
                     <version>${dep.plugin.spotbugs.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.github.spotbugs</groupId>
+                            <artifactId>spotbugs</artifactId>
+                            <version>${dep.spotbugs.version}</version>
+                        </dependency>
+                    </dependencies>
                     <configuration>
                         <effort>Max</effort>
                         <skip>${basepom.check.skip-spotbugs}</skip>


### PR DESCRIPTION
…fault. This is because they follow differing release schedules.

(For example at time of this PR, core is 3.1.7 and plugin is just 3.1.6)