### PR TITLE
Manage versions of additional commonly used plugins

### DIFF
--- a/poms/foundation/pom.xml
+++ b/poms/foundation/pom.xml
@@ -239,11 +239,16 @@
         <dep.plugin.jar.version>3.2.2</dep.plugin.jar.version>
         <dep.plugin.shade.version>3.3.0</dep.plugin.shade.version>
         <dep.plugin.source.version>3.2.1</dep.plugin.source.version>
+        <dep.plugin.ear.version>3.2.0</dep.plugin.ear.version>
+        <dep.plugin.war.version>3.3.2</dep.plugin.war.version>
 
         <!-- reporting -->
         <dep.plugin.checkstyle.version>3.2.0</dep.plugin.checkstyle.version>
         <dep.plugin.javadoc.version>3.4.1</dep.plugin.javadoc.version>
         <dep.plugin.pmd.version>3.18.0</dep.plugin.pmd.version>
+        <dep.plugin.changelog.version>2.3</dep.plugin.changelog.version>
+        <dep.plugin.jxr.version>3.3.0</dep.plugin.jxr.version>
+        <dep.plugin.taglist.version>3.0.0</dep.plugin.taglist.version>
 
         <!-- tools -->
         <dep.plugin.assembly.version>3.4.2</dep.plugin.assembly.version>
@@ -425,6 +430,12 @@
                         <groups>${basepom.test.groups}</groups>
                         <useManifestOnlyJar>false</useManifestOnlyJar>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-report-plugin</artifactId>
+                    <version>${dep.plugin.surefire.version}</version>
                 </plugin>
 
                 <plugin>
@@ -648,6 +659,24 @@
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-changelog-plugin</artifactId>
+                    <version>${dep.plugin.changelog.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jxr-plugin</artifactId>
+                    <version>${dep.plugin.jxr.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>taglist-maven-plugin</artifactId>
+                    <version>${dep.plugin.taglist.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>${dep.plugin.shade.version}</version>
                     <configuration>
@@ -667,6 +696,18 @@
                             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                         </transformers>
                     </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-ear-plugin</artifactId>
+                    <version>${dep.plugin.ear.version}</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${dep.plugin.war.version}</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Following additional, commonly used Maven plugins were added new to pluginManagement and their versions defined as properties:

- maven-jxr-plugin
- maven-ear-plugin
- maven-war-plugin
- maven-surefire-report-plugin
- maven-changelog-plugin
- taglist-maven-plugin