### PR TITLE
Update versions of several plugins

### DIFF
--- a/poms/foundation/pom.xml
+++ b/poms/foundation/pom.xml
@@ -212,16 +212,16 @@
         <basepom.maven.version>3.6.0</basepom.maven.version>
 
         <!-- https://github.com/pmd/pmd/releases -->
-        <dep.pmd.version>6.49.0</dep.pmd.version>
+        <dep.pmd.version>6.50.0</dep.pmd.version>
 
         <!-- https://github.com/checkstyle/checkstyle/releases -->
-        <dep.checkstyle.version>10.3.3</dep.checkstyle.version>
+        <dep.checkstyle.version>10.3.4</dep.checkstyle.version>
 
         <!-- https://github.com/spotbugs/spotbugs/releases -->
-        <dep.spotbugs.version>4.7.1</dep.spotbugs.version>
+        <dep.spotbugs.version>4.7.2</dep.spotbugs.version>
 
         <!-- https://github.com/apache/maven-dependency-analyzer/tags -->
-        <dep.dependency-analyzer.version>1.12.0</dep.dependency-analyzer.version>
+        <dep.dependency-analyzer.version>1.13.0</dep.dependency-analyzer.version>
 
         <!-- Plugin versions, ordered like http://maven.apache.org/plugins/ -->
 
@@ -270,7 +270,7 @@
         <dep.plugin.duplicate-finder.version>1.5.1</dep.plugin.duplicate-finder.version>
 
         <!-- https://github.com/spotbugs/spotbugs-maven-plugin/releases -->
-        <dep.plugin.spotbugs.version>4.7.1.1</dep.plugin.spotbugs.version>
+        <dep.plugin.spotbugs.version>4.7.2.1</dep.plugin.spotbugs.version>
 
         <!-- https://github.com/jacoco/jacoco/releases -->
         <dep.plugin.jacoco.version>0.8.8</dep.plugin.jacoco.version>


### PR DESCRIPTION
This PR updates versions of a several plugins to the latest released version.

Interestingly `org.asciidoctor:asciidoctorj` should also be updated 2.5.4 -> 2.5.6 according to `versions` plugin, however I do not see how it is being referenced.