### PR TITLE
Add more duplicate finder settings for JSR 330 Classes

### DIFF
--- a/poms/minimal/pom.xml
+++ b/poms/minimal/pom.xml
@@ -127,6 +127,16 @@
                                         <groupId>org.glassfish.hk2.external</groupId>
                                         <artifactId>javax.inject</artifactId>
                                     </dependency>
+                                    <!-- Can contain the classes in the javax package if using version 1.x-->
+                                    <dependency>
+                                        <groupId>jakarta.inject</groupId>
+                                        <artifactId>jakarta.inject-api</artifactId>
+                                    </dependency>
+                                    <!-- Can contain the classes in the javax package if using version 2.6.1-->
+                                    <dependency>
+                                        <groupId>org.glassfish.hk2.external</groupId>
+                                        <artifactId>jakarta.inject</artifactId>
+                                    </dependency>
                                 </conflictingDependencies>
                                 <packages>
                                     <package>javax.inject</package>


### PR DESCRIPTION
Not sure if there is a better way to go about this but the following should work.

Fixes https://github.com/basepom/basepom/issues/60