### PR TITLE
foundation: remove some invalid configuration parameters

### DIFF
--- a/poms/foundation/pom.xml
+++ b/poms/foundation/pom.xml
@@ -619,7 +619,6 @@
                         <printFailingErrors>false</printFailingErrors>
                         <verbose>true</verbose>
                         <targetJdk>${project.build.targetJdk}</targetJdk>
-                        <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
                         <minimumTokens>100</minimumTokens>
                         <failurePriority>${basepom.pmd.fail-level}</failurePriority>
                         <linkXRef>false</linkXRef>
@@ -642,7 +641,6 @@
                         <skip>${basepom.check.skip-checkstyle}</skip>
                         <failOnViolation>${basepom.check.fail-checkstyle}</failOnViolation>
                         <violationSeverity>${basepom.check.checkstyle-severity}</violationSeverity>
-                        <encoding>${project.build.sourceEncoding}</encoding>
                         <consoleOutput>true</consoleOutput>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
```
[INFO] --------------------------------[ pom ]---------------------------------
[WARNING] Parameter 'sourceEncoding' is unknown for plugin 'maven-pmd-plugin:3.19.0:check (basepom.default)'
[WARNING] Parameter 'sourceEncoding' is unknown for plugin 'maven-pmd-plugin:3.19.0:pmd (pmd)'
[WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.2.0:check (basepom.default)'
[INFO]
```