### PR TITLE
Add Maven property 'basepom.test.user.timezone' to configure system property 'user.timezone' in surefire and failsafe plugins

### DIFF
--- a/poms/foundation/pom.xml
+++ b/poms/foundation/pom.xml
@@ -80,6 +80,8 @@
         <basepom.test.timeout>30</basepom.test.timeout>
 
         <basepom.test.memory>256m</basepom.test.memory>
+        
+        <basepom.test.user.timezone />
 
         <!-- test groups for unit tests -->
         <basepom.test.groups />

--- a/poms/minimal/pom.xml
+++ b/poms/minimal/pom.xml
@@ -319,7 +319,7 @@
                     <configuration>
                         <systemPropertyVariables combine.children="append">
                             <sun.jnu.encoding>${project.build.sourceEncoding}</sun.jnu.encoding>
-                            <user.timezone>UTC</user.timezone>
+                            <user.timezone>${basepom.test.user.timezone}</user.timezone>
                             <java.awt.headless>true</java.awt.headless>
                             <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
                         </systemPropertyVariables>
@@ -332,7 +332,7 @@
                     <configuration>
                         <systemPropertyVariables combine.children="append">
                             <sun.jnu.encoding>${project.build.sourceEncoding}</sun.jnu.encoding>
-                            <user.timezone>UTC</user.timezone>
+                            <user.timezone>${basepom.test.user.timezone}</user.timezone>
                             <java.awt.headless>true</java.awt.headless>
                             <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$s %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
                         </systemPropertyVariables>


### PR DESCRIPTION
The current setting user.timezone=UTC is questionable, as the time zone setting affects all tests with unpredictable effects. The default should be the machine's default time zone i.e. an empty setting.
I was puzzled as to why slf4j simple logger uses UTC timestamps in my JUnit tests (this is how I noted the issue)