### PR TITLE
Remove forked test process timeout in surefire and failsafe plugins

### DIFF
--- a/poms/foundation/pom.xml
+++ b/poms/foundation/pom.xml
@@ -77,7 +77,7 @@
         <!-- surefire fork control -->
         <basepom.test.fork-count>0.75C</basepom.test.fork-count>
         <basepom.test.reuse-vm>true</basepom.test.reuse-vm>
-        <basepom.test.timeout>30</basepom.test.timeout>
+        <basepom.test.timeout>0</basepom.test.timeout>
 
         <basepom.test.memory>256m</basepom.test.memory>
 
@@ -91,7 +91,7 @@
         <basepom.it.skip>${skipITs}</basepom.it.skip>
         <basepom.it.memory>${basepom.test.memory}</basepom.it.memory>
         <basepom.it.fork-count>0.5C</basepom.it.fork-count>
-        <basepom.it.timeout>30</basepom.it.timeout>
+        <basepom.it.timeout>0</basepom.it.timeout>
 
         <!-- test groups for integration tests -->
         <basepom.it.groups />


### PR DESCRIPTION
The setting of `forkedProcessTimeoutInSeconds=30` (seconds) seems very short.
It means a forked test JVM is killed if it runs beyond 30 seconds.
Projects with forkCount=1 and a reasonable number of unit tests are likely to breach this limit.
The plugin default (0, meaning wait forever for the process) seems a more reasonable default.