### PR TITLE
Use latest spotbugs

### DIFF
--- a/poms/foundation/pom.xml
+++ b/poms/foundation/pom.xml
@@ -256,7 +256,7 @@
         <dep.checkstyle.version>12.0.1</dep.checkstyle.version>
 
         <!-- https://github.com/spotbugs/spotbugs/releases -->
-        <dep.spotbugs.version>4.9.6</dep.spotbugs.version>
+        <dep.spotbugs.version>4.9.7</dep.spotbugs.version>
 
         <!-- https://github.com/apache/maven-dependency-analyzer/tags -->
         <dep.dependency-analyzer.version>1.16.0</dep.dependency-analyzer.version>
@@ -302,7 +302,7 @@
         <dep.plugin.duplicate-finder.version>2.0.1</dep.plugin.duplicate-finder.version>
 
         <!-- https://github.com/spotbugs/spotbugs-maven-plugin/releases -->
-        <dep.plugin.spotbugs.version>4.9.6.0</dep.plugin.spotbugs.version>
+        <dep.plugin.spotbugs.version>4.9.7.0</dep.plugin.spotbugs.version>
 
         <!-- https://github.com/jacoco/jacoco/releases -->
         <dep.plugin.jacoco.version>0.8.14</dep.plugin.jacoco.version>


### PR DESCRIPTION
Version bump that allows spotbugs to run with java 25 support. 
Fixes https://github.com/basepom/basepom/issues/78